### PR TITLE
Update link of travis at index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,13 +70,13 @@ The following options are available:
 Continuous Integration
 ----------------------
 
-This project runs a Continuous Integration job at `travis.org`_!
+This project runs a Continuous Integration job at `travis-ci.org`_!
 
 Current Build Status: |ci|
 
 .. |ci| image:: https://secure.travis-ci.org/nicoddemus/ss.png?branch=master
 
-.. _travis.org: http://www.travis.org
+.. _travis-ci.org: https://travis-ci.org/nicoddemus/ss
 
 
 


### PR DESCRIPTION
Your old link was pointing to www.travis.org, which is a church. I know you love churches but this is too much!
