### PR TITLE
Migrate to new guessit 2 API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 description = "Command line script that automatically searches for video subtitles using OpenSubtitles.org APIs."
 long_description = ''
 
-dependencies = ['guessit>=0.7.1,<2', 'colorama']
+dependencies = ['guessit>=2', 'colorama']
 if sys.version_info <= (3, 1):
     dependencies.append('futures')
 

--- a/ss.py
+++ b/ss.py
@@ -31,7 +31,7 @@ else:  # pragma: no cover
 
 
 def obtain_guessit_query(movie_filename, language):
-    guess = guessit.guess_file_info(os.path.basename(movie_filename), info=['filename'])
+    guess = guessit.guessit(os.path.basename(movie_filename))
 
     def extract_query(guess, parts):
         result = ['"%s"' % guess.get(k) for k in parts if guess.get(k)]
@@ -39,11 +39,11 @@ def obtain_guessit_query(movie_filename, language):
 
     result = {}
     if guess.get('type') == 'episode':
-        result['query'] = extract_query(guess, ['series', 'title', 'releaseGroup'])
+        result['query'] = extract_query(guess, ['title', 'episode_title', 'release_group'])
         if 'season' in guess:
             result['season'] = guess['season']
-        if 'episodeNumber' in guess:
-            result['episode'] = guess['episodeNumber']
+        if 'episode' in guess:
+            result['episode'] = guess['episode']
 
     elif guess.get('type') == 'movie':
         result['query'] = extract_query(guess, ['title', 'year'])

--- a/tests/test_ss.py
+++ b/tests/test_ss.py
@@ -301,8 +301,8 @@ def test_embed_mkv(mocker):
     mocked_popen.assert_called_once_with(params, shell=True,
                                          stderr=subprocess.STDOUT,
                                          stdout=subprocess.PIPE)
-    popen.communicate.assert_called_once()
-    popen.poll.assert_called_once()
+    popen.communicate.assert_called_once_with()
+    popen.poll.assert_called_once_with()
 
     popen.communicate.return_value = ('failed error', '')
     popen.poll.return_value = 2


### PR DESCRIPTION
Please consider these few changes that make ss compatible with the latest versions of guessit, instead of pinning the dependancy to the older versions.